### PR TITLE
Changing calls to pyutilib.th functions

### DIFF
--- a/cute/testCUTE_asl.py
+++ b/cute/testCUTE_asl.py
@@ -19,19 +19,35 @@ import pyomo.scripting.pyomo_main as main
 import pyomo.core.expr.current as Expr
 from pyomo.opt import ProblemFormat
 from pyomo.core import *
+import pyomo.common
 
 currdir = dirname(abspath(__file__))+os.sep
+
+parameterized, param_available = pyomo.common.dependencies.attempt_import('parameterized')
+if not param_available:
+    raise unittest.SkipTest('Parameterized is not available.')
 
 #from pyomo.data.cute import CUTE_classifications as CUTE
 sys.path.append(currdir)
 import CUTE_classifications as CUTE
 sys.path.pop()
 
+smoke = []
+for name in CUTE.smoke_models:
+    smoke.append(name)
+
+expensive = []
+for name in CUTE.moderate_models:
+    expensive.append(name)
+for name in CUTE.expensive_models:
+    expensive.append(name)
+
 
 # https://github.com/ghackebeil/gjh_asl_json
 has_gjh_asl_json = False
 if os.system('gjh_asl_json -v') == 0:
     has_gjh_asl_json = True
+
 
 class Tests(unittest.TestCase):
     # These two lines can be removed after we finish the PyUtilib divorce
@@ -42,106 +58,107 @@ class Tests(unittest.TestCase):
         output = main.main(['convert', '--logging=quiet', '-c']+cmd)
         return output
 
+    def pyomo_asl(self, name):
+        if name in CUTE.asl_skipped_models:
+            self.skipTest('Ignoring test '+name)
+            return
+        if not has_gjh_asl_json:
+            self.skipTest("'gjh_asl_json' executable not available")
+            return
+        if has_json is False:
+            self.skipTest('JSON module not available')
+            return
+        self.pyomo(['--output='+currdir+name+'.test.nl',
+                    '--symbolic-solver-labels',
+                    currdir+name+'_cute.py'])
+
+        # compare AMPL and Pyomo nl file structure
+        #########################################
+        try:
+            os.remove(currdir+name+'.ampl.json')
+        except Exception:
+            pass
+        try:
+            os.remove(currdir+name+'.test.json')
+        except Exception:
+            pass
+
+        # obtain the nl file summary information for comparison with ampl
+        p = pyutilib.subprocess.run(
+            'gjh_asl_json '+currdir+name+'.test.nl rows='
+            +currdir+name+'.test.row cols='+currdir+name+'.test.col')
+        self.assertTrue(p[0] == 0, msg=p[1])
+
+        # obtain the nl file summary information for comparison with pyomo
+        p = pyutilib.subprocess.run(
+            'gjh_asl_json '+currdir+name+'.ampl.nl rows='
+            +currdir+name+'.ampl.row cols='+currdir+name+'.ampl.col')
+        self.assertTrue(p[0] == 0, msg=p[1])
+        try:
+            with open(currdir+name+'.test.json', 'r') as test, \
+                open(currdir+name+'.ampl.json', 'r') as base:
+                    self.assertStructuredAlmostEqual(test, base)
+        except AssertionError:
+            # Make sure this is not a simple case of Pyomo/AMPL moving
+            # constants in the constraint body to the upper/lower bound
+            f = open(currdir+name+'.ampl.json','r')
+            ampl_res = json.load(f)
+            f.close()
+            f = open(currdir+name+'.test.json','r')
+            pyomo_res = json.load(f)
+            f.close()
+            del ampl_res["constraint bounds"]
+            del pyomo_res["constraint bounds"]
+            del ampl_res["initial evaluations"]["constraints"]
+            del pyomo_res["initial evaluations"]["constraints"]
+            f = open(currdir+name+'.ampl.json','w')
+            json.dump(ampl_res,f,indent=2)
+            f.close()
+            f = open(currdir+name+'.test.json','w')
+            json.dump(pyomo_res,f,indent=2)
+            f.close()
+            with open(currdir+name+'.test.json', 'r') as test, \
+                open(currdir+name+'.ampl.json', 'r') as base:
+                    self.assertStructuredAlmostEqual(test, base)
+            # If the json files match at this point, it is
+            # almost entirely certain that the difference had to
+            # do with one of AMPL or Pyomo moving a fixed part
+            # of the constraint body from the body to the bounds
+            warnings.warn('asl comparison was relaxed for model '+name)
+        os.remove(currdir+name+'.ampl.json')
+
+        # delete temporary test files
+        os.remove(currdir+name+'.test.col')
+        os.remove(currdir+name+'.test.row')
+        os.remove(currdir+name+'.test.nl')
+        ##########################################
+
+
 class SmokeASLTests(Tests):
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
+
+    @parameterized.parameterized.expand(input=smoke)
+    def test_pyomo_asl_smoke(self, name):
+        self.pyomo_asl(name)
+
 
 @unittest.category('expensive')
 class ExpensiveASLTests(Tests):
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
 
-#
-# The following test calls the gjh_asl_json executable to
-# generate JSON files corresponding to both the
-# AMPL-generated nl file and the Pyomo-generated nl
-# file. The JSON files are then diffed using the pyutilib.th
-# test class method assertMatchesJsonBaseline()
-#
-@unittest.nottest
-def pyomo_asl_test(self, name):
-    if name in CUTE.asl_skipped_models:
-        self.skipTest('Ignoring test '+name)
-        return
-    if not has_gjh_asl_json:
-        self.skipTest("'gjh_asl_json' executable not available")
-        return
-    if has_json is False:
-        self.skipTest('JSON module not available')
-        return
-    self.pyomo(['--output='+currdir+name+'.test.nl',
-                '--symbolic-solver-labels',
-                currdir+name+'_cute.py'])
+    #
+    # The following test calls the gjh_asl_json executable to
+    # generate JSON files corresponding to both the
+    # AMPL-generated nl file and the Pyomo-generated nl
+    # file. The JSON files are then diffed using the pyutilib.th
+    # test class method assertMatchesJsonBaseline()
+    #
+    @parameterized.parameterized.expand(input=expensive)
+    def test_pyomo_asl_expensive(self, name):
+        self.pyomo_asl(name)
 
-    # compare AMPL and Pyomo nl file structure
-    #########################################
-    try:
-        os.remove(currdir+name+'.ampl.json')
-    except Exception:
-        pass
-    try:
-        os.remove(currdir+name+'.test.json')
-    except Exception:
-        pass
-
-    # obtain the nl file summary information for comparison with ampl
-    p = pyutilib.subprocess.run(
-        'gjh_asl_json '+currdir+name+'.test.nl rows='
-        +currdir+name+'.test.row cols='+currdir+name+'.test.col')
-    self.assertTrue(p[0] == 0, msg=p[1])
-
-    # obtain the nl file summary information for comparison with pyomo
-    p = pyutilib.subprocess.run(
-        'gjh_asl_json '+currdir+name+'.ampl.nl rows='
-        +currdir+name+'.ampl.row cols='+currdir+name+'.ampl.col')
-    self.assertTrue(p[0] == 0, msg=p[1])
-    try:
-        self.assertMatchesJsonBaseline(
-            currdir+name+'.test.json',
-            currdir+name+'.ampl.json',
-            tolerance=1e-6)
-    except AssertionError:
-        # Make sure this is not a simple case of Pyomo/AMPL moving
-        # constants in the constraint body to the upper/lower bound
-        f = open(currdir+name+'.ampl.json','r')
-        ampl_res = json.load(f)
-        f.close()
-        f = open(currdir+name+'.test.json','r')
-        pyomo_res = json.load(f)
-        f.close()
-        del ampl_res["constraint bounds"]
-        del pyomo_res["constraint bounds"]
-        del ampl_res["initial evaluations"]["constraints"]
-        del pyomo_res["initial evaluations"]["constraints"]
-        f = open(currdir+name+'.ampl.json','w')
-        json.dump(ampl_res,f,indent=2)
-        f.close()
-        f = open(currdir+name+'.test.json','w')
-        json.dump(pyomo_res,f,indent=2)
-        f.close()
-        self.assertMatchesJsonBaseline(
-            currdir+name+'.test.json',
-            currdir+name+'.ampl.json',
-            tolerance=1e-6)
-        # If the json files match at this point, it is
-        # almost entirely certain that the difference had to
-        # do with one of AMPL or Pyomo moving a fixed part
-        # of the constraint body from the body to the bounds
-        warnings.warn('asl comparison was relaxed for model '+name)
-    os.remove(currdir+name+'.ampl.json')
-
-    # delete temporary test files
-    os.remove(currdir+name+'.test.col')
-    os.remove(currdir+name+'.test.row')
-    os.remove(currdir+name+'.test.nl')
-    ##########################################
-
-for name in CUTE.smoke_models:
-    SmokeASLTests.add_fn_test(fn=pyomo_asl_test, name=name)
-for name in CUTE.moderate_models:
-    ExpensiveASLTests.add_fn_test(fn=pyomo_asl_test, name=name)
-for name in CUTE.expensive_models:
-    ExpensiveASLTests.add_fn_test(fn=pyomo_asl_test, name=name)
 
 if __name__ == "__main__":
     import pyomo.environ

--- a/cute/testCUTE_baseline.py
+++ b/cute/testCUTE_baseline.py
@@ -6,7 +6,6 @@ from itertools import zip_longest
 import sys
 import os
 from os.path import abspath, dirname, join
-from filecmp import cmp
 
 import pyomo.common.unittest as unittest
 import pyomo.scripting.pyomo_main as main

--- a/cute/testCUTE_baseline.py
+++ b/cute/testCUTE_baseline.py
@@ -74,18 +74,18 @@ class SmokeBaselineTests(Tests):
         self.pyomo_baseline(name)
 
 
-# @unittest.category('expensive')
-# class ExpensiveBaselineTests(Tests):
-#     def __init__(self, *args, **kwds):
-#         Tests.__init__(self, *args, **kwds)
+@unittest.category('expensive')
+class ExpensiveBaselineTests(Tests):
+    def __init__(self, *args, **kwds):
+        Tests.__init__(self, *args, **kwds)
 
-#     """
-#     The following test generates an nl file for the test case
-#     and checks that it matches the current pyomo baseline nl file.
-#     """
-#     @parameterized.parameterized.expand(input=expensive)
-#     def test_pyomo_baseline_expensive(self, name):
-#         self.pyomo_baseline(name)
+    """
+    The following test generates an nl file for the test case
+    and checks that it matches the current pyomo baseline nl file.
+    """
+    @parameterized.parameterized.expand(input=expensive)
+    def test_pyomo_baseline_expensive(self, name):
+        self.pyomo_baseline(name)
 
 
 if __name__ == "__main__":

--- a/cute/testCUTE_baseline.py
+++ b/cute/testCUTE_baseline.py
@@ -2,23 +2,39 @@
 # Test the NL writer on a subset of the CUTE test cases
 #
 
+from itertools import zip_longest
 import sys
 import os
-from os.path import abspath, dirname
+from os.path import abspath, dirname, join
+from filecmp import cmp
 
 import pyomo.common.unittest as unittest
-import pyutilib.subprocess
 import pyomo.scripting.pyomo_main as main
 import pyomo.core.expr.current as Expr
 from pyomo.opt import ProblemFormat
 from pyomo.core import *
+import pyomo.common
 
 currdir = dirname(abspath(__file__))+os.sep
+
+parameterized, param_available = pyomo.common.dependencies.attempt_import('parameterized')
+if not param_available:
+    raise unittest.SkipTest('Parameterized is not available.')
 
 sys.path.append(currdir)
 #from pyomo.data.cute import CUTE_classifications as CUTE
 import CUTE_classifications as CUTE
 sys.path.pop()
+
+smoke = []
+for name in CUTE.smoke_models:
+    smoke.append(name)
+
+expensive = []
+for name in CUTE.moderate_models:
+    expensive.append(name)
+for name in CUTE.expensive_models:
+    expensive.append(name)
 
 
 class Tests(unittest.TestCase):
@@ -29,39 +45,48 @@ class Tests(unittest.TestCase):
         os.chdir(currdir)
         output = main.main(['convert', '--logging=quiet', '-c']+cmd)
         return output
+    def pyomo_baseline(self, name):
+        if name in CUTE.baseline_skipped_models:
+            self.skipTest('Ignoring test '+name)
+            return
+
+        self.pyomo(['--output='+currdir+name+'.test.nl',
+                    currdir+name+'_cute.py'])
+
+        # Check that the pyomo nl file matches its own baseline
+        test, base = join(currdir, name+'.test.nl'), join(currdir, name+'.pyomo.nl')
+        with open(test, 'r') as f1, open(base, 'r') as f2:
+            f1_contents = list(filter(None, f1.read().replace('n', 'n ').split()))
+            f2_contents = list(filter(None, f2.read().replace('n', 'n ').split()))
+            for item1, item2 in zip_longest(f1_contents, f2_contents):
+                try:
+                    self.assertAlmostEqual(float(item1.strip()), float(item2.strip()))
+                except:
+                    self.assertEqual(item1, item2)
+
 
 class SmokeBaselineTests(Tests):
     def __init__(self, *args, **kwds):
         Tests.__init__(self, *args, **kwds)
 
-@unittest.category('expensive')
-class ExpensiveBaselineTests(Tests):
-    def __init__(self, *args, **kwds):
-        Tests.__init__(self, *args, **kwds)
+    @parameterized.parameterized.expand(input=smoke)
+    def test_pyomo_baseline_smoke(self, name):
+        self.pyomo_baseline(name)
 
-"""
-The following test generates an nl file for the test case
-and checks that it matches the current pyomo baseline nl file.
-"""
-@unittest.nottest
-def pyomo_baseline_test(self, name):
-    if name in CUTE.baseline_skipped_models:
-        self.skipTest('Ignoring test '+name)
-        return
 
-    self.pyomo(['--output='+currdir+name+'.test.nl',
-                currdir+name+'_cute.py'])
+# @unittest.category('expensive')
+# class ExpensiveBaselineTests(Tests):
+#     def __init__(self, *args, **kwds):
+#         Tests.__init__(self, *args, **kwds)
 
-    # Check that the pyomo nl file matches its own baseline
-    self.assertFileEqualsBaseline(
-        currdir+name+'.test.nl', currdir+name+'.pyomo.nl', tolerance=(1e-8, False))
+#     """
+#     The following test generates an nl file for the test case
+#     and checks that it matches the current pyomo baseline nl file.
+#     """
+#     @parameterized.parameterized.expand(input=expensive)
+#     def test_pyomo_baseline_expensive(self, name):
+#         self.pyomo_baseline(name)
 
-for name in CUTE.smoke_models:
-    SmokeBaselineTests.add_fn_test(fn=pyomo_baseline_test, name=name)
-for name in CUTE.moderate_models:
-    ExpensiveBaselineTests.add_fn_test(fn=pyomo_baseline_test, name=name)
-for name in CUTE.expensive_models:
-    ExpensiveBaselineTests.add_fn_test(fn=pyomo_baseline_test, name=name)
 
 if __name__ == "__main__":
     import pyomo.environ


### PR DESCRIPTION
There are some PyUtilib functions still being called in some tests (namely, `assertFileEqualsBaseline` and `assertMatchesJson`). This replaces those.