### PR TITLE
recordTestData: Add to Performance tests

### DIFF
--- a/performance/models/dae/test_stochpdegas_automatic.py
+++ b/performance/models/dae/test_stochpdegas_automatic.py
@@ -14,6 +14,16 @@ class TestStochPDEgas(unittest.TestCase):
     # These two lines can be removed after we finish the PyUtilib divorce
     pyutilib_th = 1
     pyomo_unittest = 1
+
+    @unittest.nottest
+    def recordTestData(self, name, value):
+        """A method for recording data associated with a test.  This method is only
+           meaningful when running this TestCase with 'nose', using the TestData plugin.
+        """
+        tmp = getattr(self, 'testdata', None)
+        if not tmp is None:
+            tmp[name] = value
+
     def test_stochpdegas_automatic(self):
         timer = TicTocTimer()
         from .stochpdegas_automatic import model

--- a/performance/test_models.py
+++ b/performance/test_models.py
@@ -32,10 +32,21 @@ from .models.devel import (
 
 CWD = os.getcwd()
 
+
 class TestModel(unittest.TestCase):
     # These two lines can be removed after we finish the PyUtilib divorce
     pyutilib_th = 1
     pyomo_unittest = 1
+
+    @unittest.nottest
+    def recordTestData(self, name, value):
+        """A method for recording data associated with a test.  This method is only
+           meaningful when running this TestCase with 'nose', using the TestData plugin.
+        """
+        tmp = getattr(self, 'testdata', None)
+        if not tmp is None:
+            tmp[name] = value
+
     def _run_test(self, model_lib, data):
         timer = TicTocTimer()
         if isinstance(data, six.string_types) and data.endswith('.dat'):


### PR DESCRIPTION
`recordTestData` was a `pyutilib` feature. Because it is only used in the `performance` tests, I have added it to the two test drivers in the performance suite rather than to `pyomo.common.unittest`.