### PR TITLE
Remove ranged inequalities from CUTE expensive tests

### DIFF
--- a/cute/biggsb1_cute.py
+++ b/cute/biggsb1_cute.py
@@ -42,5 +42,5 @@ def f_rule(model):
 model.f = Objective(rule=f_rule)
 
 def cons1(model,i):
-    return 0.0<=model.x[i]<=0.9
+    return inequality(0.0, model.x[i], 0.9)
 model.cons1 = Constraint(RangeSet(1,model.N-1),rule=cons1)

--- a/cute/gausselm_cute.py
+++ b/cute/gausselm_cute.py
@@ -72,7 +72,7 @@ def conspijk_rule(model,k,i,j):
 model.conspijk = Constraint(consmijk_index,rule=conspijk_rule)
 
 def var_bnd_rule(model,i,j):
-    return -1.0 <= model.x[1,i,j] <= 1.0
+    return inequality(-1.0, model.x[1,i,j], 1.0)
 model.var_bnd = Constraint(RangeSet(1,n),RangeSet(1,n),rule=var_bnd_rule)
 
 def var_bnd_diag_rule(model,k):


### PR DESCRIPTION
This removes 2 more ranged inequalities from Pyomo CUTE tests (only exercised by the expensive test suite).