### PR TITLE
Remove dependency on `six`

### DIFF
--- a/performance/main.py
+++ b/performance/main.py
@@ -11,7 +11,6 @@ except ImportError:
     import json
 
 from collections import OrderedDict
-from six import iteritems
 
 import pyomo.common.unittest as unittest
 import pyomo
@@ -99,7 +98,7 @@ class DataRecorder(nose.plugins.base.Plugin):
         test.test.testdata = self._data[addr] = OrderedDict()
         self._timingHandler.setTest(test.test.testdata)
         # disable any categories we are not interested in
-        for cat, req in iteritems(self._category):
+        for cat, req in self._category.items():
             if getattr(test.test, cat, 0):
                 setattr(test.test, cat, req)
         self._timer.tic("")

--- a/performance/test_models.py
+++ b/performance/test_models.py
@@ -1,5 +1,4 @@
 import os
-import six
 
 import pyomo.common.unittest as unittest
 
@@ -49,7 +48,7 @@ class TestModel(unittest.TestCase):
 
     def _run_test(self, model_lib, data):
         timer = TicTocTimer()
-        if isinstance(data, six.string_types) and data.endswith('.dat'):
+        if isinstance(data, str) and data.endswith('.dat'):
             model = model_lib()
             modeldir = os.path.dirname(model_lib.__code__.co_filename)
             dat_file = os.path.join(modeldir, data)


### PR DESCRIPTION
We are removing the dependency on `six` from Pyomo. We also need to remove it in `pyomo-model-libraries`.