### PR TITLE
Update tests due to changes in how Var handles bounds validation

### DIFF
--- a/performance/models/dae/stochpdegas_automatic.py
+++ b/performance/models/dae/stochpdegas_automatic.py
@@ -157,7 +157,9 @@ model.stochd = Param(model.SCEN,model.DEM,model.TIME,within=PositiveReals,mutabl
 # define temporal variables
 def p_bounds_rule(m,k,j,t):
     return (value(m.pmin[j]),value(m.pmax[j]))
-model.p = Var(model.SCEN, model.NODE, model.TIME, bounds=p_bounds_rule, initialize=50.0)
+def p_init(m,k,j,t):
+    return (value(m.pmax[j]) + value(m.pmin[j])) / 2
+model.p = Var(model.SCEN, model.NODE, model.TIME, bounds=p_bounds_rule, initialize=p_init)
 model.dp = Var(model.SCEN,model.LINK_A,model.TIME,bounds=(0.0,100.0), initialize=10.0)
 model.fin = Var(model.SCEN,model.LINK,model.TIME,bounds=(1.0,500.0),initialize=100.0)
 model.fout = Var(model.SCEN,model.LINK,model.TIME,bounds=(1.0,500.0),initialize=100.0)

--- a/performance/models/dae/stochpdegas_automatic.py
+++ b/performance/models/dae/stochpdegas_automatic.py
@@ -11,7 +11,7 @@ model = AbstractModel()
 # sets
 model.TF = Param(within=NonNegativeReals)
 def _tinit(m):
-    return [0.5,value(m.TF)]    
+    return [0.5,value(m.TF)]
     # What it should be to match description in paper
     #return [0,value(m.TF)]
 model.TIME = ContinuousSet(initialize=_tinit)
@@ -93,9 +93,9 @@ model.rand_d = Param(model.SCEN,model.DEM,within=NonNegativeReals,mutable=True)
 
 # convert units for input data
 def rescale_rule(m):
-    
+
     for i in m.LINK:
-        m.ldiam[i] = m.ldiam[i]*m.dfac         
+        m.ldiam[i] = m.ldiam[i]*m.dfac
         m.llength[i] = m.llength[i]*m.lfac
         # m.dx[i] = m.llength[i]/float(m.DIS.last())
 
@@ -112,11 +112,11 @@ def rescale_rule(m):
 model.rescale = BuildAction(rule=rescale_rule)
 
 def compute_constants(m):
-    
+
     for i in m.LINK:
         m.lam[i] = (2.0*log10(3.7*m.ldiam[i]/(m.eps*m.dfac)))**(-2.0)
         m.A[i] = (1.0/4.0)*m.pi*m.ldiam[i]*m.ldiam[i]
-        m.nu2 = m.gam*m.z*m.R*m.Tgas/m.M   
+        m.nu2 = m.gam*m.z*m.R*m.Tgas/m.M
         m.c1[i] = (m.pfac2/m.ffac2)*(m.nu2/m.A[i])
         m.c2[i] = m.A[i]*(m.ffac2/m.pfac2)
         m.c3[i] = m.A[i]*(m.pfac2/m.ffac2)*(8.0*m.lam[i]*m.nu2)/(m.pi*m.pi*(m.ldiam[i]**5.0))
@@ -126,7 +126,7 @@ model.compute_constants = BuildAction(rule=compute_constants)
 
 # set stochastic demands
 def compute_demands_rule(m):
-    
+
     for k in m.SCEN:
         for j in m.DEM:
             if k == 2:
@@ -134,7 +134,7 @@ def compute_demands_rule(m):
             elif k == 1:
                 m.rand_d[k,j] =  1.2*m.d[j]
             else:
-                m.rand_d[k,j] =  1.3*m.d[j]        
+                m.rand_d[k,j] =  1.3*m.d[j]
 model.compute_demands = BuildAction(rule=compute_demands_rule)
 
 def stochd_init(m,k,j,t):
@@ -144,13 +144,13 @@ def stochd_init(m,k,j,t):
     # if t >= m.TDEC and t < m.TDEC+5:
     #     return m.rand_d[k,j]
     # if t >= m.TDEC+5:
-    #     return m.d[j]                         
+    #     return m.d[j]
     if t < m.TDEC+1:
         return m.d[j]
     if t >= m.TDEC+1 and t < m.TDEC+1+4.5:
         return m.rand_d[k,j]
     if t >= m.TDEC+1+4.5:
-        return m.d[j]                         
+        return m.d[j]
 
 model.stochd = Param(model.SCEN,model.DEM,model.TIME,within=PositiveReals,mutable=True,default=stochd_init)
 
@@ -170,7 +170,7 @@ model.s = Var(model.SCEN,model.SUP,model.TIME,bounds=s_bounds_rule,initialize=10
 model.dem = Var(model.SCEN,model.DEM,model.TIME,initialize=100.0)
 model.pow = Var(model.SCEN,model.LINK_A,model.TIME,bounds=(0.0,3000.0),initialize=1000.0)
 model.slack = Var(model.SCEN,model.LINK,model.TIME,model.DIS,bounds=(0.0,None),initialize=10.0)
-  
+
 # define spatio-temporal variables
 model.px = Var(model.SCEN,model.LINK,model.TIME,model.DIS,bounds=(10.0,100.0),initialize=50.0)
 model.fx = Var(model.SCEN,model.LINK,model.TIME,model.DIS,bounds=(1.0,100.0),initialize=100.0)
@@ -185,10 +185,10 @@ model.dfxdx = DerivativeVar(model.fx,wrt=model.DIS,initialize=0)
 
 # compressor equations
 def powereq_rule(m,j,i,t):
-    return m.pow[j,i,t] == m.c4*m.fin[j,i,t]*(((m.p[j,m.lstartloc[i],t]+m.dp[j,i,t])/m.p[j,m.lstartloc[i],t])**m.om - 1.0) 
+    return m.pow[j,i,t] == m.c4*m.fin[j,i,t]*(((m.p[j,m.lstartloc[i],t]+m.dp[j,i,t])/m.p[j,m.lstartloc[i],t])**m.om - 1.0)
 model.powereq = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=powereq_rule)
 
-# cvar model 
+# cvar model
 model.cvar_lambda = Param(within=NonNegativeReals)
 model.nu = Var(initialize=100.0)
 model.phi = Var(model.SCEN,bounds=(0.0,None),initialize=100.0)
@@ -205,10 +205,10 @@ def nodeeq_rule(m,k,i,t):
            sum(m.fin[k,j,t] for j in m.LINK if m.lstartloc[j]==i) - \
            sum(m.dem[k,j,t] for j in m.DEM if m.dloc[j]==i) == 0.0
 model.nodeeq = Constraint(model.SCEN,model.NODE,model.TIME,rule=nodeeq_rule)
-                    
+
 # boundary conditions flow
 def flow_start_rule(m,j,i,t):
-    return m.fx[j,i,t,m.DIS.first()] == m.fin[j,i,t]    
+    return m.fx[j,i,t,m.DIS.first()] == m.fin[j,i,t]
 model.flow_start = Constraint(model.SCEN,model.LINK,model.TIME,rule=flow_start_rule)
 
 def flow_end_rule(m,j,i,t):
@@ -217,22 +217,22 @@ model.flow_end = Constraint(model.SCEN,model.LINK,model.TIME,rule=flow_end_rule)
 
 # First PDE for gas network model
 def flow_rule(m,j,i,t,k):
-    if t == m.TIME.first() or k == m.DIS.last(): 
+    if t == m.TIME.first() or k == m.DIS.last():
         return Constraint.Skip # Do not apply pde at initial time or final location
-    return m.dpxdt[j,i,t,k]/3600 + m.c1[i]/m.llength[i]*m.dfxdx[j,i,t,k] == 0 
+    return m.dpxdt[j,i,t,k]/3600 + m.c1[i]/m.llength[i]*m.dfxdx[j,i,t,k] == 0
 model.flow = Constraint(model.SCEN,model.LINK,model.TIME,model.DIS,rule=flow_rule)
 
 # Second PDE for gas network model
 def press_rule(m,j,i,t,k):
     if t == m.TIME.first() or k == m.DIS.last():
-        return Constraint.Skip # Do not apply pde at initial time or final location    
+        return Constraint.Skip # Do not apply pde at initial time or final location
     return m.dfxdt[j,i,t,k]/3600 == -m.c2[i]/m.llength[i]*m.dpxdx[j,i,t,k] - m.slack[j,i,t,k]
 model.press = Constraint(model.SCEN,model.LINK,model.TIME,model.DIS,rule=press_rule)
 
 def slackeq_rule(m,j,i,t,k):
     if t == m.TIME.last():
         return Constraint.Skip
-    return m.slack[j,i,t,k]*m.px[j,i,t,k] == m.c3[i]*m.fx[j,i,t,k]*m.fx[j,i,t,k] 
+    return m.slack[j,i,t,k]*m.px[j,i,t,k] == m.c3[i]*m.fx[j,i,t,k]*m.fx[j,i,t,k]
 model.slackeq = Constraint(model.SCEN,model.LINK,model.TIME,model.DIS,rule=slackeq_rule)
 
 # boundary conditions pressure, passive links
@@ -246,21 +246,21 @@ model.presspas_end = Constraint(model.SCEN,model.LINK_P,model.TIME,rule=presspas
 
 # boundary conditions pressure, active links
 def pressact_start_rule(m,j,i,t):
-    return m.px[j,i,t,m.DIS.first()] == m.p[j,m.lstartloc[i],t]+m.dp[j,i,t]	
+    return m.px[j,i,t,m.DIS.first()] == m.p[j,m.lstartloc[i],t]+m.dp[j,i,t]
 model.pressact_start = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=pressact_start_rule)
 
 def pressact_end_rule(m,j,i,t):
     return m.px[j,i,t,m.DIS.last()] == m.p[j,m.lendloc[i],t]
 model.pressact_end = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=pressact_end_rule)
-     
+
 # fix pressure at supply nodes
 def suppres_rule(m,k,j,t):
-    return m.p[k,m.sloc[j],t] == m.pmin[m.sloc[j]]    
+    return m.p[k,m.sloc[j],t] == m.pmin[m.sloc[j]]
 model.suppres = Constraint(model.SCEN,model.SUP,model.TIME,rule=suppres_rule)
 
 # discharge pressure for compressors
 def dispress_rule(m,j,i,t):
-    return m.p[j,m.lstartloc[i],t]+m.dp[j,i,t] <= m.pmax[m.lstartloc[i]]    
+    return m.p[j,m.lstartloc[i],t]+m.dp[j,i,t] <= m.pmax[m.lstartloc[i]]
 model.dispress = Constraint(model.SCEN,model.LINK_A,model.TIME,rule=dispress_rule)
 
 # ss constraints
@@ -273,7 +273,7 @@ model.flow_ss = Constraint(model.SCEN,model.LINK,model.DIS,rule=flow_ss_rule)
 def pres_ss_rule(m,j,i,k):
     if k == m.DIS.last():
         return Constraint.Skip
-    return 0.0 == - m.c2[i]/m.llength[i]*m.dpxdx[j,i,m.TIME.first(),k] - m.slack[j,i,m.TIME.first(),k]; 
+    return 0.0 == - m.c2[i]/m.llength[i]*m.dpxdx[j,i,m.TIME.first(),k] - m.slack[j,i,m.TIME.first(),k];
 model.pres_ss = Constraint(model.SCEN,model.LINK,model.DIS,rule=pres_ss_rule)
 
 # non-anticipativity constraints

--- a/performance/models/dae/test_stochpdegas_automatic.py
+++ b/performance/models/dae/test_stochpdegas_automatic.py
@@ -40,7 +40,7 @@ class TestStochPDEgas(unittest.TestCase):
         # What it should be to match description in paper
         #discretizer.apply_to(instance,nfe=48,wrt=instance.TIME,scheme='BACKWARD')
         
-        TimeStep = instance.TIME[2]-instance.TIME[1]
+        TimeStep = instance.TIME.at(2)-instance.TIME.at(1)
         
         def supcost_rule(m,k):
             return sum(m.cs*m.s[k,j,t]*(TimeStep) for j in m.SUP for t in m.TIME.get_finite_elements())

--- a/performance/models/dae/test_stochpdegas_automatic.py
+++ b/performance/models/dae/test_stochpdegas_automatic.py
@@ -98,3 +98,10 @@ class TestStochPDEgas(unittest.TestCase):
                     os.remove(fname)
                 except:
                     pass
+
+if __name__ == '__main__':
+    import sys
+    from pyomo.common.fileutils import this_file_dir
+    sys.path.insert(0, os.path.dirname(this_file_dir()))
+    __package__ = os.path.basename(this_file_dir())
+    unittest.main()

--- a/performance/models/dae/test_stochpdegas_automatic.py
+++ b/performance/models/dae/test_stochpdegas_automatic.py
@@ -29,13 +29,13 @@ class TestStochPDEgas(unittest.TestCase):
         from .stochpdegas_automatic import model
         instance = model.create_instance(
             os.path.join(_dir,'stochpdegas_automatic.dat'))
-        self.recordTestData('create_instance', timer.toc(''))
+        self.recordTestData('create_instance', timer.toc('create_instance'))
 
         # discretize model
         discretizer = TransformationFactory('dae.finite_difference')
         discretizer.apply_to(instance,nfe=1,wrt=instance.DIS,scheme='FORWARD')
         discretizer.apply_to(instance,nfe=47,wrt=instance.TIME,scheme='BACKWARD')
-        self.recordTestData('discretize', timer.toc(''))
+        self.recordTestData('discretize', timer.toc('discretize'))
 
         # What it should be to match description in paper
         #discretizer.apply_to(instance,nfe=48,wrt=instance.TIME,scheme='BACKWARD')
@@ -78,7 +78,7 @@ class TestStochPDEgas(unittest.TestCase):
             return (1.0-m.cvar_lambda)*m.mcost + m.cvar_lambda*m.cvarcost
         instance.obj = Objective(rule=obj_rule)
         
-        self.recordTestData('postprocessing', timer.toc(''))
+        self.recordTestData('postprocessing', timer.toc('postprocessing'))
         
 
         for fmt in ('nl', 'bar','gams'):
@@ -88,9 +88,9 @@ class TestStochPDEgas(unittest.TestCase):
             fname = 'tmp.test.'+fmt
             self.assertFalse(os.path.exists(fname))
             try:
-                timer.tic('')
+                timer.tic(None)
                 writer(instance, fname, lambda x:True, {})
-                _time = timer.toc('')
+                _time = timer.toc(fmt)
                 self.assertTrue(os.path.exists(fname))
                 self.recordTestData(fmt, _time)
             finally:

--- a/performance/models/jump/opf.py
+++ b/performance/models/jump/opf.py
@@ -38,6 +38,24 @@ def create_model(busfile, branchfile):
         b.q_max /= 100
         b.p_load /= 100
         b.q_load /= 100
+        if not( b.b_shunt_min <= b.b_shunt0 <= b.b_shunt_max ):
+            # The test data sets have invalid data.  As logged warnings
+            # (raised during data validation) significant impact both
+            # the performance test time and time variability, we will
+            # "fix" the data here so that warnings are not generated.
+            #print("DATA warning: b_shunt0[%s] = %s outside (%s, %s)"
+            #      % (i, b.b_shunt0, b.b_shunt_min, b.b_shunt_max ))
+            if b.b_dispatch == 0:
+                # The shunt will be fixed at this value.  Move the bounds
+                #print("...as this will be fixed, moving bounds to value")
+                b.b_shunt_min = b.b_shunt_max = b.b_shunt0
+            else:
+                # The shunt will be free. snap to the bounds
+                #print("...moving the value to the nearest bound")
+                if b.b_shunt0 < b.b_shunt_min:
+                    b.b_shunt0 = b.b_shunt_min
+                else:
+                    b.b_shunt0 = b.b_shunt_max
         bus.append(b)
     
     branchfile = open(branchfile, "r")

--- a/performance/models/jump/opf_quicksum.py
+++ b/performance/models/jump/opf_quicksum.py
@@ -62,6 +62,22 @@ def create_model(busfile, branchfile):
         b.def_min *= 3.14159/180
         b.def_max *= 3.14159/180
         b.def0 *= -3.14159/180
+        if not( b.b_shunt_min <= b.b_shunt0 <= b.b_shunt_max ):
+            if b.b_dispatch == 0:
+                # The shunt will be fixed at this value.  Move the bounds
+                print("DATA warning: b_shunt0[%s] = %s outside (%s, %s); as "
+                      "this will be fixed, moving bounds to accomodate value" %
+                      (i, b.b_shunt0, b.b_shunt_min, b.b_shunt_max ))
+                b.b_shunt_min = b.b_shunt_max = b.b_shunt0
+            else:
+                # The shunt will be free. snap to the bounds
+                print("DATA warning: b_shunt0[%s] = %s outside (%s, %s); "
+                      "moving the value to the nearest bound" %
+                      (i, b.b_shunt0, b.b_shunt_min, b.b_shunt_max ))
+                if b.b_shunt0 < b.b_shunt_min:
+                    b.b_shunt0 = b.b_shunt_min
+                else:
+                    b.b_shunt0 = b.b_shunt_max
         branch.append(b)
     
     

--- a/performance/test_models.py
+++ b/performance/test_models.py
@@ -40,8 +40,11 @@ class TestModel(unittest.TestCase):
 
     @unittest.nottest
     def recordTestData(self, name, value):
-        """A method for recording data associated with a test.  This method is only
-           meaningful when running this TestCase with 'nose', using the TestData plugin.
+        """A method for recording data associated with a test.
+
+        This method is only meaningful when running this TestCase with
+        'nose', using the TestData plugin.
+
         """
         tmp = getattr(self, 'testdata', None)
         if not tmp is None:
@@ -63,7 +66,7 @@ class TestModel(unittest.TestCase):
             model = model_lib(data)
         if not model.is_constructed():
             model = model.create_instance()
-        self.recordTestData('create_instance', timer.toc(''))
+        self.recordTestData('create_instance', timer.toc('create_instance'))
 
         for fmt in ('nl', 'lp','bar','gams'):
             if not getattr(self, fmt, 0):
@@ -73,9 +76,9 @@ class TestModel(unittest.TestCase):
             self.assertFalse(os.path.exists(fname))
             gc.collect()
             try:
-                timer.tic('')
+                timer.tic(None)
                 writer(model, fname, lambda x:True, {})
-                _time = timer.toc('')
+                _time = timer.toc(fmt)
                 self.assertTrue(os.path.exists(fname))
                 self.recordTestData(fmt, _time)
             finally:

--- a/performance/test_models.py
+++ b/performance/test_models.py
@@ -15,6 +15,12 @@ except ImportError:
 from pyomo.common.timing import TicTocTimer
 from pyomo.opt import WriterFactory
 
+if __name__ == '__main__':
+    import sys
+    from pyomo.common.fileutils import this_file_dir
+    sys.path.insert(0, os.path.dirname(this_file_dir()))
+    __package__ = os.path.basename(this_file_dir())
+
 from .models.misc import (
     pmedian, pmedian_quicksum, pmedian_tuple,
     bilinear, bilinear_nlcontext,
@@ -234,3 +240,7 @@ class TestDevel(TestModel):
     @unittest.category('devel')
     def test_issue_691(self):
         self._run_test(osarwar_github_issue_691.create_model, 1000)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This updates some performance tests to avoid warnings due to variables being initialized outside their bounds.  

Note that this also includes standardization of the line endings (using `dos2unix`) for `stochpdegas_automatic.py`, so when viewing the diff, update the settings to ignore whitespace.