### PR TITLE
Add nlv2 tests

### DIFF
--- a/performance/models/misc/pmedian.py
+++ b/performance/models/misc/pmedian.py
@@ -11,7 +11,7 @@
 
 from pyomo.environ import *
 
-def create_model():
+def create_model(**kwds):
     import random
 
     random.seed(1000)
@@ -51,3 +51,5 @@ def create_model():
     model.num_facilities = Constraint(rule=rule)
 
     return model
+
+pyomo_create_model = create_model

--- a/performance/models/misc/pmedian_quicksum.py
+++ b/performance/models/misc/pmedian_quicksum.py
@@ -11,7 +11,7 @@
 
 from pyomo.environ import *
 
-def create_model():
+def create_model(**kwds):
     import random
 
     random.seed(1000)
@@ -51,3 +51,5 @@ def create_model():
     model.num_facilities = Constraint(rule=rule)
 
     return model
+
+pyomo_create_model = create_model

--- a/performance/models/misc/pmedian_tuple.py
+++ b/performance/models/misc/pmedian_tuple.py
@@ -11,7 +11,7 @@
 
 from pyomo.environ import *
 
-def create_model():
+def create_model(**kwds):
     import random
 
     random.seed(1000)
@@ -51,3 +51,5 @@ def create_model():
     model.num_facilities = Constraint(rule=rule)
 
     return model
+
+pyomo_create_model = create_model

--- a/performance/test_models.py
+++ b/performance/test_models.py
@@ -70,8 +70,8 @@ class TestModel(unittest.TestCase):
             model = model.create_instance()
         self.recordData('create_instance', timer.toc('create_instance'))
         markers = [mark.name for mark in self.pytestmark]
-        for fmt in ('nl', 'lp', 'bar', 'gams'):
-            if fmt not in markers:
+        for fmt in ('nl', 'nl_v1', 'nl_v2', 'lp', 'bar', 'gams'):
+            if fmt.split('_', 1)[0] not in markers:
                 continue
             writer = WriterFactory(fmt)
             fname = os.path.join(CWD, 'tmp.test.'+fmt)


### PR DESCRIPTION
This adds explicit testing for the NLv1 and NLv2 writers and updates the pmedian  tests so they can be run through the pyomo script if desired.