### PR TITLE
Track import location changes

### DIFF
--- a/cute/test_CUTE.py
+++ b/cute/test_CUTE.py
@@ -26,8 +26,17 @@ if not param_available:
 srcdir = this_file_dir()
 
 try:
-    from pyomo.repn.tests.ampl.nl_diff import load_and_compare_nl_baseline
+    from pyomo.repn.tests.nl_diff import load_and_compare_nl_baseline
+    _loaded = True
 except ImportError:
+    _loaded = False
+if not _loaded:
+    try:
+        from pyomo.repn.tests.ampl.nl_diff import load_and_compare_nl_baseline
+        _loaded = True
+    except ImportError:
+        _loaded = False
+if not _loaded:
     # Backwards compatibility: fallback to the previous differ
     # TODO: This can be removed after the NL Writer v2 has been merged
     def load_and_compare_nl_baseline(base, test, nl_version):
@@ -53,8 +62,17 @@ except ImportError:
         return f1_contents, f2_contents
 
 try:
-    from pyomo.repn.plugins.nl_writer import FileDeterminism
+    from pyomo.repn.util import FileDeterminism
+    _loaded = True
 except ImportError:
+    _loaded = False
+if not _loaded:
+    try:
+        from pyomo.repn.plugins.nl_writer import FileDeterminism
+        _loaded = True
+    except ImportError:
+        _loaded = False
+if not _loaded:
     class FileDeterminism(object):
         ORDERED = 1
 

--- a/performance/test_models.py
+++ b/performance/test_models.py
@@ -92,7 +92,7 @@ class TestModel(unittest.TestCase):
         if not model.is_constructed():
             model = model.create_instance()
         self.recordData('create_instance', timer.toc('create_instance'))
-        for fmt in ('nl', 'nl_v1', 'nl_v2', 'lp', 'bar', 'gams'):
+        for fmt in ('nl', 'lp', 'bar', 'gams'):
             if fmt.split('_', 1)[0] not in markers:
                 continue
             writer = WriterFactory(fmt)

--- a/performance/test_models.py
+++ b/performance/test_models.py
@@ -1,4 +1,5 @@
 import gc
+import inspect
 import os
 
 import pyomo.common.unittest as unittest
@@ -38,6 +39,23 @@ from .models.devel import (
 
 CWD = os.getcwd()
 
+_calling_frame_function_locations = (
+    # local function
+    lambda frame, name: frame.f_locals.get(name, None),
+    # global function
+    lambda frame, name: frame.f_globals.get(name, None),
+    # class method (assuming the local variable for the class was 'self')
+    lambda frame, name: getattr(frame.f_locals.get('self', None), name, None),
+)
+
+def _get_calling_function():
+    frame = inspect.currentframe().f_back.f_back
+    code = frame.f_code
+    name = code.co_name
+    for get_fcn in _calling_frame_function_locations:
+        fcn = get_fcn(frame, name)
+        if getattr(fcn, '__code__', None) == code:
+            return fcn
 
 class TestModel(unittest.TestCase):
 
@@ -53,6 +71,11 @@ class TestModel(unittest.TestCase):
             tmp[name] = value
 
     def _run_test(self, model_lib, data):
+        markers = [
+            mark.name for mark in
+            getattr(self, 'pytestmark', [])
+            + getattr(_get_calling_function(), 'pytestmark', [])
+        ]
         gc.collect()
         timer = TicTocTimer()
         if isinstance(data, str) and data.endswith('.dat'):
@@ -69,7 +92,6 @@ class TestModel(unittest.TestCase):
         if not model.is_constructed():
             model = model.create_instance()
         self.recordData('create_instance', timer.toc('create_instance'))
-        markers = [mark.name for mark in self.pytestmark]
         for fmt in ('nl', 'nl_v1', 'nl_v2', 'lp', 'bar', 'gams'):
             if fmt.split('_', 1)[0] not in markers:
                 continue


### PR DESCRIPTION
The LP writer rewrite will propose that we move certain Pyomo utilities to more centralized / less obscure locations.  This PR prepares this library for that change.

This also fixes a bug in the performance tester where test markers put on the test function were not being picked up by the test driver.